### PR TITLE
BugFix

### DIFF
--- a/Client/Out-Word.ps1
+++ b/Client/Out-Word.ps1
@@ -305,15 +305,15 @@ https://github.com/samratashok/nishang
         ForEach ($WordFile in $WordFiles)
         {
             $Word = New-Object -ComObject Word.Application
-			$WordVersion = $Word.Version
-			if (($WordVersion -eq "12.0") -or  ($WordVersion -eq "11.0"))
-			{
-				$Word.DisplayAlerts = $False
-			}
-			else
-			{
-				$Word.DisplayAlerts = "wdAlertsNone"
-			}
+            $WordVersion = $Word.Version
+            if (($WordVersion -eq "12.0") -or  ($WordVersion -eq "11.0"))
+            {
+                $Word.DisplayAlerts = $False
+            }
+            else
+            {
+		$Word.DisplayAlerts = "wdAlertsNone"
+            }
             $Doc = $Word.Documents.Open($WordFile.FullName)
             $DocModule = $Doc.VBProject.VBComponents.Item(1)
             $DocModule.CodeModule.AddFromString($code_one)                  

--- a/Client/Out-Word.ps1
+++ b/Client/Out-Word.ps1
@@ -305,7 +305,15 @@ https://github.com/samratashok/nishang
         ForEach ($WordFile in $WordFiles)
         {
             $Word = New-Object -ComObject Word.Application
-            $Word.DisplayAlerts = $False
+			$WordVersion = $Word.Version
+			if (($WordVersion -eq "12.0") -or  ($WordVersion -eq "11.0"))
+			{
+				$Word.DisplayAlerts = $False
+			}
+			else
+			{
+				$Word.DisplayAlerts = "wdAlertsNone"
+			}
             $Doc = $Word.Documents.Open($WordFile.FullName)
             $DocModule = $Doc.VBProject.VBComponents.Item(1)
             $DocModule.CodeModule.AddFromString($code_one)                  
@@ -325,7 +333,7 @@ https://github.com/samratashok/nishang
             }
             else
             {
-                $Doc.Saveas([ref]$SavePath, 0)
+                $Doc.Saveas([ref]$SavePath, [ref]0)
             } 
             Write-Output "Saved to file $SavePath"
             $Doc.Close()


### PR DESCRIPTION
The **$Word.DisplayAlerts** gets defaulted to **$False** in "infection" phase. That's not valid for newer version of MS Word. I applied (reused code form the beginning of the script) additional check so that it does not throw errors for newer versions of MS Word.

Additionally, some errors where thrown due to missing **[ref]** while the infected file is being saved in environments with newer MS Word versions. However, this should be further tested in order to verify if it does not require specific checks of MS Word version.
