### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/powerpreter/README.md
+++ b/powerpreter/README.md
@@ -1,6 +1,6 @@
-#####Powerpreter is a script module which makes it useful in scenarios like drive-by-download, document attachments, webshells etc. where one may like to pull all the functionality in Nishang in a single file or where deployment is not easy to do. Powerpreter has persistence capabilities too. See examples for help in using it.
+##### Powerpreter is a script module which makes it useful in scenarios like drive-by-download, document attachments, webshells etc. where one may like to pull all the functionality in Nishang in a single file or where deployment is not easy to do. Powerpreter has persistence capabilities too. See examples for help in using it.
 
-#####Examples
+##### Examples
 
 .EXAMPLE
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
